### PR TITLE
FL-1161/1532 Export provides created date

### DIFF
--- a/tests/fixtures/input/fields-out-of-order.php
+++ b/tests/fixtures/input/fields-out-of-order.php
@@ -13,7 +13,7 @@ $testInput = [
         'identifier' => 'client-xyz',
         'tag' => 'widget-1-campaign',
         'version' => 1,
-        'created' => '2015-04-16 21:51:52',
+        'created' => '2015-04-16 21:50:39',
         'data' => '{"comment":"booyah!","lastName":"Terwilliger","firstName":"Bob","age":"42"}'
     ],
     [

--- a/tests/fixtures/output/first-row-missing-data-field.csv
+++ b/tests/fixtures/output/first-row-missing-data-field.csv
@@ -1,3 +1,3 @@
-age,comment,firstName,lastName
-42,booyah!,Bob,Terwilliger
-130,Excellent,Monte,Burns
+age,comment,created,firstName,lastName
+42,booyah!,"2015-04-16 09:51:52 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 06:43:15 pm",Monte,Burns

--- a/tests/fixtures/output/good-CDT.csv
+++ b/tests/fixtures/output/good-CDT.csv
@@ -1,0 +1,4 @@
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 04:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 04:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 01:43:15 pm",Monte,Burns

--- a/tests/fixtures/output/good-CST.csv
+++ b/tests/fixtures/output/good-CST.csv
@@ -1,0 +1,4 @@
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 03:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 03:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 12:43:15 pm",Monte,Burns

--- a/tests/fixtures/output/good-EDT.csv
+++ b/tests/fixtures/output/good-EDT.csv
@@ -1,0 +1,4 @@
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 05:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 05:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 02:43:15 pm",Monte,Burns

--- a/tests/fixtures/output/good-EST.csv
+++ b/tests/fixtures/output/good-EST.csv
@@ -1,0 +1,4 @@
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 04:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 04:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 01:43:15 pm",Monte,Burns

--- a/tests/fixtures/output/good-MDT.csv
+++ b/tests/fixtures/output/good-MDT.csv
@@ -1,0 +1,4 @@
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 03:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 03:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 12:43:15 pm",Monte,Burns

--- a/tests/fixtures/output/good-MST.csv
+++ b/tests/fixtures/output/good-MST.csv
@@ -1,0 +1,4 @@
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 02:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 02:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 11:43:15 am",Monte,Burns

--- a/tests/fixtures/output/good-PDT.csv
+++ b/tests/fixtures/output/good-PDT.csv
@@ -1,0 +1,4 @@
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 02:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 02:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 11:43:15 am",Monte,Burns

--- a/tests/fixtures/output/good-PST.csv
+++ b/tests/fixtures/output/good-PST.csv
@@ -1,0 +1,4 @@
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 01:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 01:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 10:43:15 am",Monte,Burns

--- a/tests/fixtures/output/good.csv
+++ b/tests/fixtures/output/good.csv
@@ -1,4 +1,4 @@
-age,comment,firstName,lastName
-47,Amen,Ned,Flanders
-42,booyah!,Bob,Terwilliger
-130,Excellent,Monte,Burns
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 09:51:52 pm",Ned,Flanders
+42,booyah!,"2015-04-16 09:50:39 pm",Bob,Terwilliger
+130,Excellent,"2015-04-16 06:43:15 pm",Monte,Burns

--- a/tests/fixtures/output/one-row-with-extra-field.csv
+++ b/tests/fixtures/output/one-row-with-extra-field.csv
@@ -1,4 +1,4 @@
-age,comment,extra,firstName,lastName
-47,Amen,,Ned,Flanders
-42,booyah!,field,Bob,Terwilliger
-130,Excellent,,Monte,Burns
+age,comment,created,extra,firstName,lastName
+47,Amen,"2015-04-16 09:51:52 pm",,Ned,Flanders
+42,booyah!,"2015-04-16 09:50:39 pm",field,Bob,Terwilliger
+130,Excellent,"2015-04-16 06:43:15 pm",,Monte,Burns

--- a/tests/fixtures/output/second-row-missing-data-field.csv
+++ b/tests/fixtures/output/second-row-missing-data-field.csv
@@ -1,3 +1,3 @@
-age,comment,firstName,lastName
-47,Amen,Ned,Flanders
-130,Excellent,Monte,Burns
+age,comment,created,firstName,lastName
+47,Amen,"2015-04-16 09:51:52 pm",Ned,Flanders
+130,Excellent,"2015-04-16 06:43:15 pm",Monte,Burns


### PR DESCRIPTION
- Modified FormExporter to tack on the created date value for each lead record.
- Formats the created date in the timezone specified by the UTC offset included in the startDate parameter.
- If no timezone is specified, defaults to UTC +0:00.
